### PR TITLE
pa-m:optimize - Changed maxFev param type from  int to int64 for 32-bit builds.

### DIFF
--- a/brentminimize.go
+++ b/brentminimize.go
@@ -6,7 +6,7 @@ import (
 
 type bracketer struct {
 	growLimit float64
-	maxIter   int
+	maxIter   int64
 }
 
 // Bracket the minimum of the function.
@@ -15,10 +15,10 @@ type bracketer struct {
 // new points xa, xb, xc that bracket the minimum of the function
 // f(xa) > f(xb) < f(xc). It doesn't always mean that obtained
 // solution will satisfy xa<=x<=xb
-func (b bracketer) bracket(f func(float64) float64, xa0, xb0 float64) (xa, xb, xc, fa, fb, fc float64, funcalls int) {
+func (b bracketer) bracket(f func(float64) float64, xa0, xb0 float64) (xa, xb, xc, fa, fb, fc float64, funcalls int64) {
 	var (
 		tmp1, tmp2, val, denom, w, wlim, fw float64
-		iter                                int
+		iter                                int64
 	)
 	_gold := 1.618034 //# golden ratio: (1.0+sqrt(5.0))/2.0
 	_verysmallNum := 1e-21
@@ -100,19 +100,19 @@ func (b bracketer) bracket(f func(float64) float64, xa0, xb0 float64) (xa, xb, x
 type BrentMinimizer struct {
 	Func           func(float64) float64
 	Tol            float64
-	Maxiter        int
+	Maxiter        int64
 	mintol         float64
 	cg             float64
 	Xmin           float64
 	Fval           float64
-	Iter, Funcalls int
+	Iter, Funcalls int64
 	Brack          []float64
 	bracketer
-	FnMaxFev func(int) bool
+	FnMaxFev func(int64) bool
 }
 
 // NewBrentMinimizer returns an initialized *BrentMinimizer
-func NewBrentMinimizer(fun func(float64) float64, tol float64, maxiter int, fnMaxFev func(int) bool) *BrentMinimizer {
+func NewBrentMinimizer(fun func(float64) float64, tol float64, maxiter int64, fnMaxFev func(int64) bool) *BrentMinimizer {
 	return &BrentMinimizer{
 		Func:      fun,
 		Tol:       tol,
@@ -129,12 +129,12 @@ func (bm *BrentMinimizer) SetBracket(brack []float64) {
 	bm.Brack = make([]float64, len(brack))
 	copy(bm.Brack, brack)
 }
-func (bm *BrentMinimizer) getBracketInfo() (float64, float64, float64, float64, float64, float64, int) {
+func (bm *BrentMinimizer) getBracketInfo() (float64, float64, float64, float64, float64, float64, int64) {
 	fun := bm.Func
 	brack := bm.Brack
 	var xa, xb, xc float64
 	var fa, fb, fc float64
-	var funcalls int
+	var funcalls int64
 	switch len(brack) {
 	case 0:
 		xa, xb, xc, fa, fb, fc, funcalls = bm.bracketer.bracket(fun, 0, 1)
@@ -155,10 +155,10 @@ func (bm *BrentMinimizer) getBracketInfo() (float64, float64, float64, float64, 
 }
 
 // Optimize search the value of X minimizing bm.Func
-func (bm *BrentMinimizer) Optimize() (x, fx float64, iter, funcalls int) {
+func (bm *BrentMinimizer) Optimize() (x, fx float64, iter int64, funcalls int64) {
 	var xa, xb, xc, fb, _mintol, _cg, v, fv, w, fw, a, b, deltax, tol1, tol2, xmid, rat, tmp1, tmp2, p, dxTemp, u, fu float64
 	if bm.FnMaxFev == nil {
-		bm.FnMaxFev = func(int) bool { return false }
+		bm.FnMaxFev = func(int64) bool { return false }
 	}
 	//# set up for optimization
 	f := bm.Func

--- a/brentminimize_test.go
+++ b/brentminimize_test.go
@@ -7,8 +7,9 @@ import (
 func ExampleBrentMinimizer() {
 	f := func(x float64) float64 { return x * x }
 	tol := 1e-8
-	maxIter := 500
-	fnMaxFev := func(nfev int) bool { return nfev > 1500 }
+	var maxIter int64
+	maxIter = 500
+	fnMaxFev := func(nfev int64) bool { return nfev > 1500 }
 	bm := NewBrentMinimizer(f, tol, maxIter, fnMaxFev)
 	bm.Brack = []float64{1, 2}
 	x, fx, nIter, nFev := bm.Optimize()

--- a/powellmethod.go
+++ b/powellmethod.go
@@ -52,8 +52,8 @@ func (g *Powell) updateMajor(operation chan<- optimize.Task, task optimize.Task)
 // Run for Powell to implement gonum optimize.Method
 func (g *Powell) Run(operation chan<- optimize.Task, result <-chan optimize.Task, tasks []optimize.Task) {
 	var stop bool
-	fnMaxIter := func(int) bool { return stop }
-	fnMaxFev := func(int) bool { return stop }
+	fnMaxIter := func(int64) bool { return stop }
+	fnMaxFev := func(int64) bool { return stop }
 
 	if g.PM == nil {
 		g.PM = NewPowellMinimizer()


### PR DESCRIPTION
I'm using pa-m:sklearn/preprocessing StandardScaler and I get this error when trying to build for x86:
 - optimize/powell.go:34:16: constant 9223372036854775807 overflows int

To fix this, I have modified 3 files in pa-m:optimize and changed fnMaxFev param from type int to type int64.

I also changed sklearn:preprocessing/data.go and will create a separate PR.

After these changes I can successfully build for x86 without problems.
All tests are also passing.